### PR TITLE
fix: ensure BR bots leave waiting platform

### DIFF
--- a/src/strategy/actions/BattleGroundTactics.cpp
+++ b/src/strategy/actions/BattleGroundTactics.cpp
@@ -1567,12 +1567,16 @@ bool BGTactics::brJumpDown()
     if (bgType != BATTLEGROUND_BR)
         return false;
 
-    if (bg->GetStatus() != STATUS_IN_PROGRESS)
+    // Wait until the battleground has at least started its join countdown.
+    // This allows bots to leave the platform even if the match has not fully
+    // begun yet, avoiding them being stuck when it eventually starts.
+    if (bg->GetStatus() <= STATUS_WAIT_QUEUE)
         return false;
 
     // Trigger a jump only while the bot is still on the waiting platform to
-    // prevent them from being stuck after the match starts.
-    if (bot->GetPositionZ() > 210.0f && bot->GetDistance(BR_WAITING_PLATFORM) < 100.0f)
+    // prevent them from being stuck after the match starts. Increase the
+    // distance threshold to account for wider spawn areas on the platform.
+    if (bot->GetPositionZ() > 210.0f && bot->GetDistance(BR_WAITING_PLATFORM) < 250.0f)
     {
         uint32 index = urand(0u, maxStormStartPositions - 1);
         Position const& dest = StormStartPositions[index].Position;
@@ -1580,6 +1584,11 @@ bool BGTactics::brJumpDown()
         float y = dest.GetPositionY() + frand(-20.0f, 20.0f);
 
         bot->TeleportTo(bg->GetMapId(), x, y, dest.GetPositionZ(), bot->GetOrientation());
+
+        bot->SetCanFly(false);
+        bot->RemoveUnitMovementFlag(MOVEMENTFLAG_FLYING);
+        bot->RemoveUnitMovementFlag(MOVEMENTFLAG_DISABLE_GRAVITY);
+        bot->SendMovementFlagUpdate();
 
         if (bot->GetItemByEntry(BR_PARACHUTE_ITEM))
             bot->CastSpell(bot, BR_PARACHUTE_SPELL, true);


### PR DESCRIPTION
## Summary
- allow Battle Royale bots to jump once the battleground join countdown starts
- expand waiting platform radius to cover all spawn positions
- re-enable gravity for Battle Royale bots after teleporting to drop points

## Testing
- `clang-format -i -lines=1580:1599 src/strategy/actions/BattleGroundTactics.cpp`


------
https://chatgpt.com/codex/tasks/task_b_68b34f903c188325a52e1d671e0682dd