### PR TITLE
refactor: replace boost threads with std threads

### DIFF
--- a/src/PlayerbotCommandServer.cpp
+++ b/src/PlayerbotCommandServer.cpp
@@ -6,9 +6,8 @@
 #include "PlayerbotCommandServer.h"
 
 #include <boost/asio.hpp>
-#include <boost/bind.hpp>
 #include <boost/smart_ptr.hpp>
-#include <boost/thread/thread.hpp>
+#include <thread>
 #include <cstdlib>
 #include <iostream>
 
@@ -66,7 +65,8 @@ void server(Acore::Asio::IoContext& io_service, short port)
     {
         socket_ptr sock(new tcp::socket(io_service));
         a.accept(*sock);
-        boost::thread t(boost::bind(session, sock));
+        std::thread t(session, sock);
+        t.detach();
     }
 }
 

--- a/src/RandomPlayerbotMgr.cpp
+++ b/src/RandomPlayerbotMgr.cpp
@@ -8,7 +8,7 @@
 #include <WorldSessionMgr.h>
 
 #include <algorithm>
-#include <boost/thread/thread.hpp>
+#include <thread>
 #include <cstdlib>
 #include <ctime>
 #include <iomanip>
@@ -106,7 +106,7 @@ void PrintStatsThread() { sRandomPlayerbotMgr->PrintStats(); }
 
 void activatePrintStatsThread()
 {
-    boost::thread t(PrintStatsThread);
+    std::thread t(PrintStatsThread);
     t.detach();
 }
 
@@ -114,7 +114,7 @@ void CheckBgQueueThread() { sRandomPlayerbotMgr->CheckBgQueue(); }
 
 void activateCheckBgQueueThread()
 {
-    boost::thread t(CheckBgQueueThread);
+    std::thread t(CheckBgQueueThread);
     t.detach();
 }
 
@@ -122,7 +122,7 @@ void CheckLfgQueueThread() { sRandomPlayerbotMgr->CheckLfgQueue(); }
 
 void activateCheckLfgQueueThread()
 {
-    boost::thread t(CheckLfgQueueThread);
+    std::thread t(CheckLfgQueueThread);
     t.detach();
 }
 
@@ -130,7 +130,7 @@ void CheckPlayersThread() { sRandomPlayerbotMgr->CheckPlayers(); }
 
 void activateCheckPlayersThread()
 {
-    boost::thread t(CheckPlayersThread);
+    std::thread t(CheckPlayersThread);
     t.detach();
 }
 


### PR DESCRIPTION
## Summary
- remove Boost thread usage in RandomPlayerbotMgr
- replace Boost thread spawning in PlayerbotCommandServer

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_b_68c70a7e1b3c832594c31a021142d767